### PR TITLE
Persist filters to local storage

### DIFF
--- a/lib/src/models/processes.dart
+++ b/lib/src/models/processes.dart
@@ -109,10 +109,18 @@ class WorkItemType {
             .toList(),
       );
 
-  static WorkItemType get all {
+  static WorkItemType get all => WorkItemType(
+        name: 'All',
+        referenceName: 'All',
+        isDisabled: false,
+        icon: '',
+        states: [],
+      );
+
+  static WorkItemType onlyName({required String name}) {
     return WorkItemType(
-      name: 'All',
-      referenceName: 'All',
+      name: name,
+      referenceName: name,
       isDisabled: false,
       icon: '',
       states: [],
@@ -163,13 +171,17 @@ class WorkItemState {
         color: json['color'] as String,
       );
 
-  static WorkItemState get all {
-    return WorkItemState(
-      name: 'All',
-      color: '',
-      id: '',
-    );
-  }
+  static WorkItemState get all => WorkItemState(
+        name: 'All',
+        color: '',
+        id: '',
+      );
+  
+  static WorkItemState onlyName({required String name}) => WorkItemState(
+        name: name,
+        color: '',
+        id: '',
+      );
 
   final String id;
   final String name;

--- a/lib/src/models/processes.dart
+++ b/lib/src/models/processes.dart
@@ -176,7 +176,7 @@ class WorkItemState {
         color: '',
         id: '',
       );
-  
+
   static WorkItemState onlyName({required String name}) => WorkItemState(
         name: name,
         color: '',

--- a/lib/src/screens/commits/base_commits.dart
+++ b/lib/src/screens/commits/base_commits.dart
@@ -8,6 +8,7 @@ import 'package:azure_devops/src/models/project.dart';
 import 'package:azure_devops/src/models/user.dart';
 import 'package:azure_devops/src/router/router.dart';
 import 'package:azure_devops/src/services/azure_api_service.dart';
+import 'package:azure_devops/src/services/filters_service.dart';
 import 'package:azure_devops/src/services/storage_service.dart';
 import 'package:azure_devops/src/theme/theme.dart';
 import 'package:azure_devops/src/widgets/app_page.dart';

--- a/lib/src/screens/commits/controller_commits.dart
+++ b/lib/src/screens/commits/controller_commits.dart
@@ -33,7 +33,10 @@ class _CommitsController with FilterMixin {
 
   final recentCommits = ValueNotifier<ApiResponse<List<Commit>?>?>(null);
 
-  late final filtersService = FiltersService(storageService: storageService, apiService: apiService);
+  late final filtersService = FiltersService(
+    storageService: storageService,
+    organization: apiService.organization,
+  );
 
   void dispose() {
     instance = null;

--- a/lib/src/screens/commits/controller_commits.dart
+++ b/lib/src/screens/commits/controller_commits.dart
@@ -41,6 +41,12 @@ class _CommitsController with FilterMixin {
   }
 
   Future<void> init() async {
+    _fillSavedFilters();
+
+    await _getData();
+  }
+
+  void _fillSavedFilters() {
     final savedFilters = filtersService.getCommitsSavedFilters();
 
     if (savedFilters.projects.isNotEmpty) {
@@ -50,8 +56,6 @@ class _CommitsController with FilterMixin {
     if (savedFilters.authors.isNotEmpty) {
       usersFilter = getSortedUsers(apiService).where((p) => savedFilters.authors.contains(p.mailAddress)).toSet();
     }
-
-    await _getData();
   }
 
   Future<void> _getData() async {

--- a/lib/src/screens/pipelines/base_pipelines.dart
+++ b/lib/src/screens/pipelines/base_pipelines.dart
@@ -9,6 +9,7 @@ import 'package:azure_devops/src/models/project.dart';
 import 'package:azure_devops/src/models/user.dart';
 import 'package:azure_devops/src/router/router.dart';
 import 'package:azure_devops/src/services/azure_api_service.dart';
+import 'package:azure_devops/src/services/filters_service.dart';
 import 'package:azure_devops/src/services/storage_service.dart';
 import 'package:azure_devops/src/theme/theme.dart';
 import 'package:azure_devops/src/widgets/app_page.dart';

--- a/lib/src/screens/pipelines/controller_pipelines.dart
+++ b/lib/src/screens/pipelines/controller_pipelines.dart
@@ -44,7 +44,10 @@ class _PipelinesController with FilterMixin {
   final visibilityKey = GlobalKey();
   var _hasStoppedTimer = false;
 
-  late final filtersService = FiltersService(storageService: storageService, apiService: apiService);
+  late final filtersService = FiltersService(
+    storageService: storageService,
+    organization: apiService.organization,
+  );
 
   void dispose() {
     _stopTimer();

--- a/lib/src/screens/pipelines/controller_pipelines.dart
+++ b/lib/src/screens/pipelines/controller_pipelines.dart
@@ -44,6 +44,8 @@ class _PipelinesController with FilterMixin {
   final visibilityKey = GlobalKey();
   var _hasStoppedTimer = false;
 
+  late final filtersService = FiltersService(storageService: storageService, apiService: apiService);
+
   void dispose() {
     _stopTimer();
 
@@ -57,6 +59,22 @@ class _PipelinesController with FilterMixin {
   }
 
   Future<void> init() async {
+    final savedFilters = filtersService.getPipelinesSavedFilters();
+
+    if (savedFilters.projects.isNotEmpty) {
+      projectsFilter = getProjects(storageService).where((p) => savedFilters.projects.contains(p.name)).toSet();
+    }
+
+    if (savedFilters.triggeredBy.isNotEmpty) {
+      usersFilter = getSortedUsers(apiService).where((p) => savedFilters.triggeredBy.contains(p.mailAddress)).toSet();
+    }
+
+    if (savedFilters.result.isNotEmpty) {
+      resultFilter = PipelineResult.fromString(savedFilters.result.first);
+    } else if (savedFilters.status.isNotEmpty) {
+      statusFilter = PipelineStatus.fromString(savedFilters.status.first);
+    }
+
     await _getData();
 
     if (pipelines.value != null) {
@@ -113,6 +131,8 @@ class _PipelinesController with FilterMixin {
     pipelines.value = null;
     projectsFilter = projects;
     _getData();
+
+    filtersService.savePipelinesProjectsFilter(projects.map((p) => p.name!).toSet());
   }
 
   void filterByResult(PipelineResult result) {
@@ -121,6 +141,8 @@ class _PipelinesController with FilterMixin {
     pipelines.value = null;
     resultFilter = result;
     _getData();
+
+    filtersService.savePipelinesResultFilter(result.stringValue);
   }
 
   void filterByStatus(PipelineStatus status) {
@@ -129,6 +151,8 @@ class _PipelinesController with FilterMixin {
     pipelines.value = null;
     statusFilter = status;
     _getData();
+
+    filtersService.savePipelinesStatusFilter(status.stringValue);
   }
 
   void filterByUsers(Set<GraphUser> users) {
@@ -137,6 +161,8 @@ class _PipelinesController with FilterMixin {
     pipelines.value = null;
     usersFilter = users;
     _getData();
+
+    filtersService.savePipelinesTriggeredByFilter(users.map((p) => p.mailAddress!).toSet());
   }
 
   void resetFilters() {
@@ -146,6 +172,8 @@ class _PipelinesController with FilterMixin {
     usersFilter.clear();
 
     if (args?.definition == null) projectsFilter.clear();
+
+    filtersService.resetPipelinesFilters();
 
     init();
   }

--- a/lib/src/screens/pipelines/controller_pipelines.dart
+++ b/lib/src/screens/pipelines/controller_pipelines.dart
@@ -59,21 +59,7 @@ class _PipelinesController with FilterMixin {
   }
 
   Future<void> init() async {
-    final savedFilters = filtersService.getPipelinesSavedFilters();
-
-    if (savedFilters.projects.isNotEmpty) {
-      projectsFilter = getProjects(storageService).where((p) => savedFilters.projects.contains(p.name)).toSet();
-    }
-
-    if (savedFilters.triggeredBy.isNotEmpty) {
-      usersFilter = getSortedUsers(apiService).where((p) => savedFilters.triggeredBy.contains(p.mailAddress)).toSet();
-    }
-
-    if (savedFilters.result.isNotEmpty) {
-      resultFilter = PipelineResult.fromString(savedFilters.result.first);
-    } else if (savedFilters.status.isNotEmpty) {
-      statusFilter = PipelineStatus.fromString(savedFilters.status.first);
-    }
+    _fillSavedFilters();
 
     await _getData();
 
@@ -90,6 +76,24 @@ class _PipelinesController with FilterMixin {
           }
         });
       }
+    }
+  }
+
+  void _fillSavedFilters() {
+    final savedFilters = filtersService.getPipelinesSavedFilters();
+
+    if (savedFilters.projects.isNotEmpty) {
+      projectsFilter = getProjects(storageService).where((p) => savedFilters.projects.contains(p.name)).toSet();
+    }
+
+    if (savedFilters.triggeredBy.isNotEmpty) {
+      usersFilter = getSortedUsers(apiService).where((p) => savedFilters.triggeredBy.contains(p.mailAddress)).toSet();
+    }
+
+    if (savedFilters.result.isNotEmpty) {
+      resultFilter = PipelineResult.fromString(savedFilters.result.first);
+    } else if (savedFilters.status.isNotEmpty) {
+      statusFilter = PipelineStatus.fromString(savedFilters.status.first);
     }
   }
 

--- a/lib/src/screens/pull_requests/base_pull_requests.dart
+++ b/lib/src/screens/pull_requests/base_pull_requests.dart
@@ -6,6 +6,7 @@ import 'package:azure_devops/src/models/pull_request.dart';
 import 'package:azure_devops/src/models/user.dart';
 import 'package:azure_devops/src/router/router.dart';
 import 'package:azure_devops/src/services/azure_api_service.dart';
+import 'package:azure_devops/src/services/filters_service.dart';
 import 'package:azure_devops/src/services/storage_service.dart';
 import 'package:azure_devops/src/theme/theme.dart';
 import 'package:azure_devops/src/widgets/app_page.dart';

--- a/lib/src/screens/pull_requests/controller_pull_requests.dart
+++ b/lib/src/screens/pull_requests/controller_pull_requests.dart
@@ -40,7 +40,10 @@ class _PullRequestsController with FilterMixin {
   final isSearching = ValueNotifier<bool>(false);
   String? _currentSearchQuery;
 
-  late final filtersService = FiltersService(storageService: storageService, apiService: apiService);
+  late final filtersService = FiltersService(
+    storageService: storageService,
+    organization: apiService.organization,
+  );
 
   void dispose() {
     instance = null;

--- a/lib/src/screens/pull_requests/controller_pull_requests.dart
+++ b/lib/src/screens/pull_requests/controller_pull_requests.dart
@@ -48,6 +48,12 @@ class _PullRequestsController with FilterMixin {
   }
 
   Future<void> init() async {
+    _fillSavedFilters();
+
+    await _getData();
+  }
+
+  void _fillSavedFilters() {
     final savedFilters = filtersService.getPullRequestsSavedFilters();
 
     if (savedFilters.projects.isNotEmpty) {
@@ -66,8 +72,6 @@ class _PullRequestsController with FilterMixin {
       reviewersFilter =
           getSortedUsers(apiService).where((p) => savedFilters.assignedTo.contains(p.mailAddress)).toSet();
     }
-
-    await _getData();
   }
 
   Future<void> goToPullRequestDetail(PullRequest pr) async {

--- a/lib/src/screens/pull_requests/controller_pull_requests.dart
+++ b/lib/src/screens/pull_requests/controller_pull_requests.dart
@@ -40,12 +40,33 @@ class _PullRequestsController with FilterMixin {
   final isSearching = ValueNotifier<bool>(false);
   String? _currentSearchQuery;
 
+  late final filtersService = FiltersService(storageService: storageService, apiService: apiService);
+
   void dispose() {
     instance = null;
     _instances.remove(project.hashCode);
   }
 
   Future<void> init() async {
+    final savedFilters = filtersService.getPullRequestsSavedFilters();
+
+    if (savedFilters.projects.isNotEmpty) {
+      projectsFilter = getProjects(storageService).where((p) => savedFilters.projects.contains(p.name)).toSet();
+    }
+
+    if (savedFilters.status.isNotEmpty) {
+      statusFilter = PullRequestStatus.fromString(savedFilters.status.first);
+    }
+
+    if (savedFilters.openedBy.isNotEmpty) {
+      usersFilter = getSortedUsers(apiService).where((p) => savedFilters.openedBy.contains(p.mailAddress)).toSet();
+    }
+
+    if (savedFilters.assignedTo.isNotEmpty) {
+      reviewersFilter =
+          getSortedUsers(apiService).where((p) => savedFilters.assignedTo.contains(p.mailAddress)).toSet();
+    }
+
     await _getData();
   }
 
@@ -58,12 +79,14 @@ class _PullRequestsController with FilterMixin {
     await init();
   }
 
-  void filterByStatus(PullRequestStatus state) {
-    if (state == statusFilter) return;
+  void filterByStatus(PullRequestStatus status) {
+    if (status == statusFilter) return;
 
     pullRequests.value = null;
-    statusFilter = state;
+    statusFilter = status;
     _getData();
+
+    filtersService.savePullRequestsStatusFilter(status.name);
   }
 
   void filterByUsers(Set<GraphUser> users) {
@@ -72,6 +95,8 @@ class _PullRequestsController with FilterMixin {
     pullRequests.value = null;
     usersFilter = users;
     _getData();
+
+    filtersService.savePullRequestsOpenedByFilter(users.map((p) => p.mailAddress!).toSet());
   }
 
   void filterByReviewers(Set<GraphUser> users) {
@@ -80,6 +105,8 @@ class _PullRequestsController with FilterMixin {
     pullRequests.value = null;
     reviewersFilter = users;
     _getData();
+
+    filtersService.savePullRequestsAssignedToFilter(users.map((p) => p.mailAddress!).toSet());
   }
 
   void filterByProjects(Set<Project> projects) {
@@ -88,6 +115,8 @@ class _PullRequestsController with FilterMixin {
     pullRequests.value = null;
     projectsFilter = projects;
     _getData();
+
+    filtersService.savePullRequestsProjectsFilter(projects.map((p) => p.name!).toSet());
   }
 
   Future<void> _getData() async {
@@ -112,6 +141,8 @@ class _PullRequestsController with FilterMixin {
     statusFilter = PullRequestStatus.all;
     usersFilter.clear();
     reviewersFilter.clear();
+
+    filtersService.resetPullRequestsFilters();
 
     init();
   }

--- a/lib/src/screens/work_items/base_work_items.dart
+++ b/lib/src/screens/work_items/base_work_items.dart
@@ -11,6 +11,7 @@ import 'package:azure_devops/src/models/user.dart';
 import 'package:azure_devops/src/models/work_items.dart';
 import 'package:azure_devops/src/router/router.dart';
 import 'package:azure_devops/src/services/azure_api_service.dart';
+import 'package:azure_devops/src/services/filters_service.dart';
 import 'package:azure_devops/src/services/storage_service.dart';
 import 'package:azure_devops/src/theme/dev_ops_icons_icons.dart';
 import 'package:azure_devops/src/theme/theme.dart';

--- a/lib/src/screens/work_items/controller_work_items.dart
+++ b/lib/src/screens/work_items/controller_work_items.dart
@@ -57,35 +57,7 @@ class _WorkItemsController with FilterMixin {
   }
 
   Future<void> init() async {
-    final savedFilters = filtersService.getWorkItemsSavedFilters();
-
-    if (savedFilters.projects.isNotEmpty) {
-      projectsFilter = getProjects(storageService).where((p) => savedFilters.projects.contains(p.name)).toSet();
-    }
-
-    if (savedFilters.assignees.isNotEmpty) {
-      usersFilter = getAssignees().where((p) => savedFilters.assignees.contains(p.mailAddress)).toSet();
-    }
-
-    if (savedFilters.area.isNotEmpty) {
-      // we may not have real areas yet, so we use a fake one to show the filter immediately
-      areaFilter = AreaOrIteration.onlyPath(path: savedFilters.area.first);
-    }
-
-    if (savedFilters.iteration.isNotEmpty) {
-      // we may not have real iterations yet, so we use a fake one to show the filter immediately
-      iterationFilter = AreaOrIteration.onlyPath(path: savedFilters.iteration.first);
-    }
-
-    if (savedFilters.types.isNotEmpty) {
-      // we may not have real types yet, so we use a fake one to show the filter immediately
-      typesFilter = savedFilters.types.map((t) => WorkItemType.onlyName(name: t)).toSet();
-    }
-
-    if (savedFilters.states.isNotEmpty) {
-      // we may not have real states yet, so we use a fake one to show the filter immediately
-      statesFilter = savedFilters.states.map((s) => WorkItemState.onlyName(name: s)).toSet();
-    }
+    final savedFilters = _fillSavedFilters();
 
     allWorkItemTypes = [];
     allWorkItemStates = statesFilter.toList();
@@ -106,7 +78,6 @@ class _WorkItemsController with FilterMixin {
     await _getData();
 
     if (savedFilters.area.isNotEmpty) {
-      // use a real area for area filter
       areaFilter = apiService.workItemAreas.values
           .expand((a) => a)
           .expand((a) => [a, if (a.children != null) ...a.children!])
@@ -114,12 +85,44 @@ class _WorkItemsController with FilterMixin {
     }
 
     if (savedFilters.iteration.isNotEmpty) {
-      // use a real iteration for iteration filter
       apiService.workItemIterations.values
           .expand((a) => a)
           .expand((a) => [a, if (a.children != null) ...a.children!])
           .firstWhereOrNull((a) => a.path == savedFilters.iteration.first);
     }
+  }
+
+  /// Here we fill some filters with fake objects just to show them immediately,
+  /// because we may not have the real object yet (areas, iterations, types and states
+  /// need to get downloaded).
+  WorkItemsFilters _fillSavedFilters() {
+    final savedFilters = filtersService.getWorkItemsSavedFilters();
+
+    if (savedFilters.projects.isNotEmpty) {
+      projectsFilter = getProjects(storageService).where((p) => savedFilters.projects.contains(p.name)).toSet();
+    }
+
+    if (savedFilters.assignees.isNotEmpty) {
+      usersFilter = getAssignees().where((p) => savedFilters.assignees.contains(p.mailAddress)).toSet();
+    }
+
+    if (savedFilters.area.isNotEmpty) {
+      areaFilter = AreaOrIteration.onlyPath(path: savedFilters.area.first);
+    }
+
+    if (savedFilters.iteration.isNotEmpty) {
+      iterationFilter = AreaOrIteration.onlyPath(path: savedFilters.iteration.first);
+    }
+
+    if (savedFilters.types.isNotEmpty) {
+      typesFilter = savedFilters.types.map((t) => WorkItemType.onlyName(name: t)).toSet();
+    }
+
+    if (savedFilters.states.isNotEmpty) {
+      statesFilter = savedFilters.states.map((s) => WorkItemState.onlyName(name: s)).toSet();
+    }
+
+    return savedFilters;
   }
 
   void _fillTypesAndStates(Iterable<List<WorkItemType>> values) {

--- a/lib/src/screens/work_items/controller_work_items.dart
+++ b/lib/src/screens/work_items/controller_work_items.dart
@@ -60,8 +60,7 @@ class _WorkItemsController with FilterMixin {
     final savedFilters = filtersService.getWorkItemsSavedFilters();
 
     if (savedFilters.projects.isNotEmpty) {
-      projectsFilter =
-          getProjects(storageService).where((p) => savedFilters.projects.contains(p.name)).toSet();
+      projectsFilter = getProjects(storageService).where((p) => savedFilters.projects.contains(p.name)).toSet();
     }
 
     if (savedFilters.assignees.isNotEmpty) {

--- a/lib/src/screens/work_items/controller_work_items.dart
+++ b/lib/src/screens/work_items/controller_work_items.dart
@@ -57,15 +57,15 @@ class _WorkItemsController with FilterMixin {
   }
 
   Future<void> init() async {
-    final savedWorkItemsFilters = filtersService.getWorkItemsSavedFilters();
+    final savedFilters = filtersService.getWorkItemsSavedFilters();
 
-    if (savedWorkItemsFilters.projects.isNotEmpty) {
+    if (savedFilters.projects.isNotEmpty) {
       projectsFilter =
-          getProjects(storageService).where((p) => savedWorkItemsFilters.projects.contains(p.name)).toSet();
+          getProjects(storageService).where((p) => savedFilters.projects.contains(p.name)).toSet();
     }
 
-    if (savedWorkItemsFilters.assignees.isNotEmpty) {
-      usersFilter = getAssignees().where((p) => savedWorkItemsFilters.assignees.contains(p.mailAddress)).toSet();
+    if (savedFilters.assignees.isNotEmpty) {
+      usersFilter = getAssignees().where((p) => savedFilters.assignees.contains(p.mailAddress)).toSet();
     }
 
     allWorkItemTypes = [];
@@ -75,12 +75,12 @@ class _WorkItemsController with FilterMixin {
     if (!types.isError) {
       _fillTypesAndStates(types.data!.values);
 
-      if (savedWorkItemsFilters.types.isNotEmpty) {
-        typesFilter = allWorkItemTypes.where((s) => savedWorkItemsFilters.types.contains(s.name)).toSet();
+      if (savedFilters.types.isNotEmpty) {
+        typesFilter = allWorkItemTypes.where((s) => savedFilters.types.contains(s.name)).toSet();
       }
 
-      if (savedWorkItemsFilters.states.isNotEmpty) {
-        statesFilter = allWorkItemStates.where((s) => savedWorkItemsFilters.states.contains(s.name)).toSet();
+      if (savedFilters.states.isNotEmpty) {
+        statesFilter = allWorkItemStates.where((s) => savedFilters.states.contains(s.name)).toSet();
       }
     }
 

--- a/lib/src/screens/work_items/controller_work_items.dart
+++ b/lib/src/screens/work_items/controller_work_items.dart
@@ -49,7 +49,10 @@ class _WorkItemsController with FilterMixin {
 
   bool get isDefaultStateFilter => statesFilter.isEmpty;
 
-  late final filtersService = FiltersService(storageService: storageService, apiService: apiService);
+  late final filtersService = FiltersService(
+    storageService: storageService,
+    organization: apiService.organization,
+  );
 
   void dispose() {
     instance = null;

--- a/lib/src/services/filters_service.dart
+++ b/lib/src/services/filters_service.dart
@@ -12,21 +12,15 @@ class FiltersService {
   String get organization => apiService.organization;
 
   WorkItemsFilters getWorkItemsSavedFilters() {
-    final savedFilters = storageService.getFilters();
-
-    final workItemsFilters = savedFilters
-        .where(
-          (f) => f.organization == organization && f.area == _FilterAreas.workItems,
-        )
-        .toList();
+    final workItemsFilters = _getAreaFilter(area: _FilterAreas.workItems);
 
     return WorkItemsFilters(
-      projects: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.projectsKey)?.filters ?? {},
-      states: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.statesKey)?.filters ?? {},
-      types: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.typesKey)?.filters ?? {},
-      assignees: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.assigneesKey)?.filters ?? {},
-      area: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.areaKey)?.filters ?? {},
-      iteration: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.iterationKey)?.filters ?? {},
+      projects: _getFilters(workItemsFilters, attribute: WorkItemsFilters.projectsKey),
+      states: _getFilters(workItemsFilters, attribute: WorkItemsFilters.statesKey),
+      types: _getFilters(workItemsFilters, attribute: WorkItemsFilters.typesKey),
+      assignees: _getFilters(workItemsFilters, attribute: WorkItemsFilters.assigneesKey),
+      area: _getFilters(workItemsFilters, attribute: WorkItemsFilters.areaKey),
+      iteration: _getFilters(workItemsFilters, attribute: WorkItemsFilters.iterationKey),
     );
   }
 
@@ -59,17 +53,11 @@ class FiltersService {
   }
 
   CommitsFilters getCommitsSavedFilters() {
-    final savedFilters = storageService.getFilters();
-
-    final commitsFilters = savedFilters
-        .where(
-          (f) => f.organization == organization && f.area == _FilterAreas.commits,
-        )
-        .toList();
+    final commitsFilters = _getAreaFilter(area: _FilterAreas.commits);
 
     return CommitsFilters(
-      projects: commitsFilters.firstWhereOrNull((f) => f.attribute == CommitsFilters.projectsKey)?.filters ?? {},
-      authors: commitsFilters.firstWhereOrNull((f) => f.attribute == CommitsFilters.authorsKey)?.filters ?? {},
+      projects: _getFilters(commitsFilters, attribute: CommitsFilters.projectsKey),
+      authors: _getFilters(commitsFilters, attribute: CommitsFilters.authorsKey),
     );
   }
 
@@ -86,20 +74,13 @@ class FiltersService {
   }
 
   PipelinesFilters getPipelinesSavedFilters() {
-    final savedFilters = storageService.getFilters();
-
-    final pipelinesFilters = savedFilters
-        .where(
-          (f) => f.organization == organization && f.area == _FilterAreas.pipelines,
-        )
-        .toList();
+    final pipelinesFilters = _getAreaFilter(area: _FilterAreas.pipelines);
 
     return PipelinesFilters(
-      projects: pipelinesFilters.firstWhereOrNull((f) => f.attribute == PipelinesFilters.projectsKey)?.filters ?? {},
-      triggeredBy:
-          pipelinesFilters.firstWhereOrNull((f) => f.attribute == PipelinesFilters.triggeredByKey)?.filters ?? {},
-      result: pipelinesFilters.firstWhereOrNull((f) => f.attribute == PipelinesFilters.resultKey)?.filters ?? {},
-      status: pipelinesFilters.firstWhereOrNull((f) => f.attribute == PipelinesFilters.statusKey)?.filters ?? {},
+      projects: _getFilters(pipelinesFilters, attribute: PipelinesFilters.projectsKey),
+      triggeredBy: _getFilters(pipelinesFilters, attribute: PipelinesFilters.triggeredByKey),
+      result: _getFilters(pipelinesFilters, attribute: PipelinesFilters.resultKey),
+      status: _getFilters(pipelinesFilters, attribute: PipelinesFilters.statusKey),
     );
   }
 
@@ -124,22 +105,13 @@ class FiltersService {
   }
 
   PullRequestsFilters getPullRequestsSavedFilters() {
-    final savedFilters = storageService.getFilters();
-
-    final pullRequestsFilters = savedFilters
-        .where(
-          (f) => f.organization == organization && f.area == _FilterAreas.pullRequests,
-        )
-        .toList();
+    final pullRequestsFilters = _getAreaFilter(area: _FilterAreas.pullRequests);
 
     return PullRequestsFilters(
-      projects:
-          pullRequestsFilters.firstWhereOrNull((f) => f.attribute == PullRequestsFilters.projectsKey)?.filters ?? {},
-      status: pullRequestsFilters.firstWhereOrNull((f) => f.attribute == PullRequestsFilters.statusKey)?.filters ?? {},
-      openedBy:
-          pullRequestsFilters.firstWhereOrNull((f) => f.attribute == PullRequestsFilters.openedByKey)?.filters ?? {},
-      assignedTo:
-          pullRequestsFilters.firstWhereOrNull((f) => f.attribute == PullRequestsFilters.assignedToKey)?.filters ?? {},
+      projects: _getFilters(pullRequestsFilters, attribute: PullRequestsFilters.projectsKey),
+      status: _getFilters(pullRequestsFilters, attribute: PullRequestsFilters.statusKey),
+      openedBy: _getFilters(pullRequestsFilters, attribute: PullRequestsFilters.openedByKey),
+      assignedTo: _getFilters(pullRequestsFilters, attribute: PullRequestsFilters.assignedToKey),
     );
   }
 
@@ -161,6 +133,15 @@ class FiltersService {
 
   void resetPullRequestsFilters() {
     storageService.resetFilter(organization, _FilterAreas.pullRequests);
+  }
+
+  List<StorageFilter> _getAreaFilter({required String area}) {
+    final savedFilters = storageService.getFilters();
+    return savedFilters.where((f) => f.organization == organization && f.area == area).toList();
+  }
+
+  Set<String> _getFilters(List<StorageFilter> allFilters, {required String attribute}) {
+    return allFilters.firstWhereOrNull((f) => f.attribute == attribute)?.filters ?? {};
   }
 }
 

--- a/lib/src/services/filters_service.dart
+++ b/lib/src/services/filters_service.dart
@@ -2,6 +2,8 @@ import 'package:azure_devops/src/services/azure_api_service.dart';
 import 'package:azure_devops/src/services/storage_service.dart';
 import 'package:collection/collection.dart';
 
+// TODO save work items area and iteration filters
+
 /// This class is responsible for persisting filters to local storage.
 class FiltersService {
   FiltersService({required this.storageService, required this.apiService});
@@ -14,17 +16,17 @@ class FiltersService {
   WorkItemsFilters getWorkItemsSavedFilters() {
     final savedFilters = storageService.getFilters();
 
-    final savedWorkItemsFilters = savedFilters
+    final workItemsFilters = savedFilters
         .where(
           (f) => f.organization == organization && f.area == _FilterAreas.workItems,
         )
         .toList();
 
     return WorkItemsFilters(
-      projects: savedWorkItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
-      states: savedWorkItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.states)?.filters ?? {},
-      types: savedWorkItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.types)?.filters ?? {},
-      assignees: savedWorkItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.assignees)?.filters ?? {},
+      projects: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
+      states: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.states)?.filters ?? {},
+      types: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.types)?.filters ?? {},
+      assignees: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.assignees)?.filters ?? {},
     );
   }
 
@@ -51,15 +53,15 @@ class FiltersService {
   CommitsFilters getCommitsSavedFilters() {
     final savedFilters = storageService.getFilters();
 
-    final savedCommitsFilters = savedFilters
+    final commitsFilters = savedFilters
         .where(
           (f) => f.organization == organization && f.area == _FilterAreas.commits,
         )
         .toList();
 
     return CommitsFilters(
-      projects: savedCommitsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
-      authors: savedCommitsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.authors)?.filters ?? {},
+      projects: commitsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
+      authors: commitsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.authors)?.filters ?? {},
     );
   }
 
@@ -73,6 +75,43 @@ class FiltersService {
 
   void resetCommitsFilters() {
     storageService.resetFilter(organization, _FilterAreas.commits);
+  }
+
+  PipelinesFilters getPipelinesSavedFilters() {
+    final savedFilters = storageService.getFilters();
+
+    final pipelinesFilters = savedFilters
+        .where(
+          (f) => f.organization == organization && f.area == _FilterAreas.pipelines,
+        )
+        .toList();
+
+    return PipelinesFilters(
+      projects: pipelinesFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
+      triggeredBy: pipelinesFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.triggeredBy)?.filters ?? {},
+      result: pipelinesFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.result)?.filters ?? {},
+      status: pipelinesFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.status)?.filters ?? {},
+    );
+  }
+
+  void savePipelinesProjectsFilter(Set<String> projectNames) {
+    storageService.saveFilter(organization, _FilterAreas.pipelines, _FilterKeys.projects, projectNames);
+  }
+
+  void savePipelinesTriggeredByFilter(Set<String> userEmails) {
+    storageService.saveFilter(organization, _FilterAreas.pipelines, _FilterKeys.triggeredBy, userEmails);
+  }
+
+  void savePipelinesResultFilter(String result) {
+    storageService.saveFilter(organization, _FilterAreas.pipelines, _FilterKeys.result, {result});
+  }
+
+  void savePipelinesStatusFilter(String status) {
+    storageService.saveFilter(organization, _FilterAreas.pipelines, _FilterKeys.status, {status});
+  }
+
+  void resetPipelinesFilters() {
+    storageService.resetFilter(organization, _FilterAreas.pipelines);
   }
 }
 
@@ -100,18 +139,36 @@ class CommitsFilters {
   final Set<String> authors;
 }
 
+class PipelinesFilters {
+  PipelinesFilters({
+    required this.projects,
+    required this.triggeredBy,
+    required this.result,
+    required this.status,
+  });
+
+  final Set<String> projects;
+  final Set<String> triggeredBy;
+  final Set<String> result;
+  final Set<String> status;
+}
+
 class _FilterAreas {
   static const workItems = 'work-items';
   static const commits = 'commits';
+  static const pipelines = 'pipelines';
   // TODO
-  // static const pipelines = 'pipelines';
   // static const pullRequests = 'pull-requests';
 }
 
+// TODO move keys in each area class
 class _FilterKeys {
   static const projects = 'projects';
   static const states = 'states';
   static const types = 'types';
   static const assignees = 'assignees';
   static const authors = 'authors';
+  static const triggeredBy = 'triggeredBy';
+  static const result = 'result';
+  static const status = 'status';
 }

--- a/lib/src/services/filters_service.dart
+++ b/lib/src/services/filters_service.dart
@@ -1,0 +1,79 @@
+import 'package:azure_devops/src/services/azure_api_service.dart';
+import 'package:azure_devops/src/services/storage_service.dart';
+import 'package:collection/collection.dart';
+
+/// This class is responsible for persisting filters to local storage.
+class FiltersService {
+  FiltersService({required this.storageService, required this.apiService});
+
+  final StorageService storageService;
+  final AzureApiService apiService;
+
+  String get organization => apiService.organization;
+
+  WorkItemsFilters getWorkItemsSavedFilters() {
+    final savedFilters = storageService.getFilters();
+
+    final savedWorkItemsFilters = savedFilters
+        .where(
+          (f) => f.organization == organization && f.area == _FilterAreas.workItems,
+        )
+        .toList();
+
+    return WorkItemsFilters(
+      projects: savedWorkItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
+      states: savedWorkItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.states)?.filters ?? {},
+      types: savedWorkItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.types)?.filters ?? {},
+      assignees: savedWorkItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.assignees)?.filters ?? {},
+    );
+  }
+
+  void saveWorkItemsProjectsFilter(Set<String> projectNames) {
+    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.projects, projectNames);
+  }
+
+  void saveWorkItemsStatesFilter(Set<String> stateNames) {
+    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.states, stateNames);
+  }
+
+  void saveWorkItemsTypesFilter(Set<String> typeNames) {
+    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.types, typeNames);
+  }
+
+  void saveWorkItemsAssigneesFilter(Set<String> userEmails) {
+    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.assignees, userEmails);
+  }
+
+  void resetWorkItemsFilters() {
+    storageService.resetFilter(organization, _FilterAreas.workItems);
+  }
+}
+
+class WorkItemsFilters {
+  WorkItemsFilters({
+    required this.projects,
+    required this.states,
+    required this.types,
+    required this.assignees,
+  });
+
+  final Set<String> projects;
+  final Set<String> states;
+  final Set<String> types;
+  final Set<String> assignees;
+}
+
+class _FilterAreas {
+  static const workItems = 'work-items';
+  // TODO
+  // static const commits = 'commits';
+  // static const pipelines = 'pipelines';
+  // static const pullRequests = 'pull-requests';
+}
+
+class _FilterKeys {
+  static const projects = 'projects';
+  static const states = 'states';
+  static const types = 'types';
+  static const assignees = 'assignees';
+}

--- a/lib/src/services/filters_service.dart
+++ b/lib/src/services/filters_service.dart
@@ -2,8 +2,6 @@ import 'package:azure_devops/src/services/azure_api_service.dart';
 import 'package:azure_devops/src/services/storage_service.dart';
 import 'package:collection/collection.dart';
 
-// TODO save work items area and iteration filters
-
 /// This class is responsible for persisting filters to local storage.
 class FiltersService {
   FiltersService({required this.storageService, required this.apiService});
@@ -27,6 +25,8 @@ class FiltersService {
       states: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.states)?.filters ?? {},
       types: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.types)?.filters ?? {},
       assignees: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.assignees)?.filters ?? {},
+      area: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.area)?.filters ?? {},
+      iteration: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.iteration)?.filters ?? {},
     );
   }
 
@@ -44,6 +44,14 @@ class FiltersService {
 
   void saveWorkItemsAssigneesFilter(Set<String> userEmails) {
     storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.assignees, userEmails);
+  }
+
+  void saveWorkItemsAreaFilter(String area) {
+    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.area, {area});
+  }
+
+  void saveWorkItemsIterationFilter(String iteration) {
+    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.iteration, {iteration});
   }
 
   void resetWorkItemsFilters() {
@@ -158,12 +166,16 @@ class WorkItemsFilters {
     required this.states,
     required this.types,
     required this.assignees,
+    required this.area,
+    required this.iteration,
   });
 
   final Set<String> projects;
   final Set<String> states;
   final Set<String> types;
   final Set<String> assignees;
+  final Set<String> area;
+  final Set<String> iteration;
 }
 
 class CommitsFilters {
@@ -217,6 +229,8 @@ class _FilterKeys {
   static const states = 'states';
   static const types = 'types';
   static const assignees = 'assignees';
+  static const area = 'area';
+  static const iteration = 'iteration';
   static const authors = 'authors';
   static const triggeredBy = 'triggeredBy';
   static const result = 'result';

--- a/lib/src/services/filters_service.dart
+++ b/lib/src/services/filters_service.dart
@@ -21,37 +21,37 @@ class FiltersService {
         .toList();
 
     return WorkItemsFilters(
-      projects: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
-      states: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.states)?.filters ?? {},
-      types: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.types)?.filters ?? {},
-      assignees: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.assignees)?.filters ?? {},
-      area: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.area)?.filters ?? {},
-      iteration: workItemsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.iteration)?.filters ?? {},
+      projects: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.projectsKey)?.filters ?? {},
+      states: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.statesKey)?.filters ?? {},
+      types: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.typesKey)?.filters ?? {},
+      assignees: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.assigneesKey)?.filters ?? {},
+      area: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.areaKey)?.filters ?? {},
+      iteration: workItemsFilters.firstWhereOrNull((f) => f.attribute == WorkItemsFilters.iterationKey)?.filters ?? {},
     );
   }
 
   void saveWorkItemsProjectsFilter(Set<String> projectNames) {
-    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.projects, projectNames);
+    storageService.saveFilter(organization, _FilterAreas.workItems, WorkItemsFilters.projectsKey, projectNames);
   }
 
   void saveWorkItemsStatesFilter(Set<String> stateNames) {
-    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.states, stateNames);
+    storageService.saveFilter(organization, _FilterAreas.workItems, WorkItemsFilters.statesKey, stateNames);
   }
 
   void saveWorkItemsTypesFilter(Set<String> typeNames) {
-    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.types, typeNames);
+    storageService.saveFilter(organization, _FilterAreas.workItems, WorkItemsFilters.typesKey, typeNames);
   }
 
   void saveWorkItemsAssigneesFilter(Set<String> userEmails) {
-    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.assignees, userEmails);
+    storageService.saveFilter(organization, _FilterAreas.workItems, WorkItemsFilters.assigneesKey, userEmails);
   }
 
   void saveWorkItemsAreaFilter(String area) {
-    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.area, {area});
+    storageService.saveFilter(organization, _FilterAreas.workItems, WorkItemsFilters.areaKey, {area});
   }
 
   void saveWorkItemsIterationFilter(String iteration) {
-    storageService.saveFilter(organization, _FilterAreas.workItems, _FilterKeys.iteration, {iteration});
+    storageService.saveFilter(organization, _FilterAreas.workItems, WorkItemsFilters.iterationKey, {iteration});
   }
 
   void resetWorkItemsFilters() {
@@ -68,17 +68,17 @@ class FiltersService {
         .toList();
 
     return CommitsFilters(
-      projects: commitsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
-      authors: commitsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.authors)?.filters ?? {},
+      projects: commitsFilters.firstWhereOrNull((f) => f.attribute == CommitsFilters.projectsKey)?.filters ?? {},
+      authors: commitsFilters.firstWhereOrNull((f) => f.attribute == CommitsFilters.authorsKey)?.filters ?? {},
     );
   }
 
   void saveCommitsProjectsFilter(Set<String> projectNames) {
-    storageService.saveFilter(organization, _FilterAreas.commits, _FilterKeys.projects, projectNames);
+    storageService.saveFilter(organization, _FilterAreas.commits, CommitsFilters.projectsKey, projectNames);
   }
 
   void saveCommitsAuthorsFilter(Set<String> userEmails) {
-    storageService.saveFilter(organization, _FilterAreas.commits, _FilterKeys.authors, userEmails);
+    storageService.saveFilter(organization, _FilterAreas.commits, CommitsFilters.authorsKey, userEmails);
   }
 
   void resetCommitsFilters() {
@@ -95,27 +95,28 @@ class FiltersService {
         .toList();
 
     return PipelinesFilters(
-      projects: pipelinesFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
-      triggeredBy: pipelinesFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.triggeredBy)?.filters ?? {},
-      result: pipelinesFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.result)?.filters ?? {},
-      status: pipelinesFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.status)?.filters ?? {},
+      projects: pipelinesFilters.firstWhereOrNull((f) => f.attribute == PipelinesFilters.projectsKey)?.filters ?? {},
+      triggeredBy:
+          pipelinesFilters.firstWhereOrNull((f) => f.attribute == PipelinesFilters.triggeredByKey)?.filters ?? {},
+      result: pipelinesFilters.firstWhereOrNull((f) => f.attribute == PipelinesFilters.resultKey)?.filters ?? {},
+      status: pipelinesFilters.firstWhereOrNull((f) => f.attribute == PipelinesFilters.statusKey)?.filters ?? {},
     );
   }
 
   void savePipelinesProjectsFilter(Set<String> projectNames) {
-    storageService.saveFilter(organization, _FilterAreas.pipelines, _FilterKeys.projects, projectNames);
+    storageService.saveFilter(organization, _FilterAreas.pipelines, PipelinesFilters.projectsKey, projectNames);
   }
 
   void savePipelinesTriggeredByFilter(Set<String> userEmails) {
-    storageService.saveFilter(organization, _FilterAreas.pipelines, _FilterKeys.triggeredBy, userEmails);
+    storageService.saveFilter(organization, _FilterAreas.pipelines, PipelinesFilters.triggeredByKey, userEmails);
   }
 
   void savePipelinesResultFilter(String result) {
-    storageService.saveFilter(organization, _FilterAreas.pipelines, _FilterKeys.result, {result});
+    storageService.saveFilter(organization, _FilterAreas.pipelines, PipelinesFilters.resultKey, {result});
   }
 
   void savePipelinesStatusFilter(String status) {
-    storageService.saveFilter(organization, _FilterAreas.pipelines, _FilterKeys.status, {status});
+    storageService.saveFilter(organization, _FilterAreas.pipelines, PipelinesFilters.statusKey, {status});
   }
 
   void resetPipelinesFilters() {
@@ -132,27 +133,30 @@ class FiltersService {
         .toList();
 
     return PullRequestsFilters(
-      projects: pullRequestsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
-      status: pullRequestsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.status)?.filters ?? {},
-      openedBy: pullRequestsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.openedBy)?.filters ?? {},
-      assignedTo: pullRequestsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.assignees)?.filters ?? {},
+      projects:
+          pullRequestsFilters.firstWhereOrNull((f) => f.attribute == PullRequestsFilters.projectsKey)?.filters ?? {},
+      status: pullRequestsFilters.firstWhereOrNull((f) => f.attribute == PullRequestsFilters.statusKey)?.filters ?? {},
+      openedBy:
+          pullRequestsFilters.firstWhereOrNull((f) => f.attribute == PullRequestsFilters.openedByKey)?.filters ?? {},
+      assignedTo:
+          pullRequestsFilters.firstWhereOrNull((f) => f.attribute == PullRequestsFilters.assignedToKey)?.filters ?? {},
     );
   }
 
   void savePullRequestsProjectsFilter(Set<String> projectNames) {
-    storageService.saveFilter(organization, _FilterAreas.pullRequests, _FilterKeys.projects, projectNames);
+    storageService.saveFilter(organization, _FilterAreas.pullRequests, PullRequestsFilters.projectsKey, projectNames);
   }
 
   void savePullRequestsStatusFilter(String status) {
-    storageService.saveFilter(organization, _FilterAreas.pullRequests, _FilterKeys.status, {status});
+    storageService.saveFilter(organization, _FilterAreas.pullRequests, PullRequestsFilters.statusKey, {status});
   }
 
   void savePullRequestsOpenedByFilter(Set<String> userEmails) {
-    storageService.saveFilter(organization, _FilterAreas.pullRequests, _FilterKeys.openedBy, userEmails);
+    storageService.saveFilter(organization, _FilterAreas.pullRequests, PullRequestsFilters.openedByKey, userEmails);
   }
 
   void savePullRequestsAssignedToFilter(Set<String> userEmails) {
-    storageService.saveFilter(organization, _FilterAreas.pullRequests, _FilterKeys.assignees, userEmails);
+    storageService.saveFilter(organization, _FilterAreas.pullRequests, PullRequestsFilters.assignedToKey, userEmails);
   }
 
   void resetPullRequestsFilters() {
@@ -170,6 +174,13 @@ class WorkItemsFilters {
     required this.iteration,
   });
 
+  static const projectsKey = 'projects';
+  static const statesKey = 'states';
+  static const typesKey = 'types';
+  static const assigneesKey = 'assignees';
+  static const areaKey = 'area';
+  static const iterationKey = 'iteration';
+
   final Set<String> projects;
   final Set<String> states;
   final Set<String> types;
@@ -184,6 +195,9 @@ class CommitsFilters {
     required this.authors,
   });
 
+  static const projectsKey = 'projects';
+  static const authorsKey = 'authors';
+
   final Set<String> projects;
   final Set<String> authors;
 }
@@ -195,6 +209,11 @@ class PipelinesFilters {
     required this.result,
     required this.status,
   });
+
+  static const projectsKey = 'projects';
+  static const triggeredByKey = 'triggeredBy';
+  static const resultKey = 'result';
+  static const statusKey = 'status';
 
   final Set<String> projects;
   final Set<String> triggeredBy;
@@ -210,6 +229,11 @@ class PullRequestsFilters {
     required this.assignedTo,
   });
 
+  static const projectsKey = 'projects';
+  static const statusKey = 'status';
+  static const openedByKey = 'openedBy';
+  static const assignedToKey = 'assignedTo';
+
   final Set<String> projects;
   final Set<String> status;
   final Set<String> openedBy;
@@ -221,19 +245,4 @@ class _FilterAreas {
   static const commits = 'commits';
   static const pipelines = 'pipelines';
   static const pullRequests = 'pull-requests';
-}
-
-// TODO move keys in each area class
-class _FilterKeys {
-  static const projects = 'projects';
-  static const states = 'states';
-  static const types = 'types';
-  static const assignees = 'assignees';
-  static const area = 'area';
-  static const iteration = 'iteration';
-  static const authors = 'authors';
-  static const triggeredBy = 'triggeredBy';
-  static const result = 'result';
-  static const status = 'status';
-  static const openedBy = 'openedBy';
 }

--- a/lib/src/services/filters_service.dart
+++ b/lib/src/services/filters_service.dart
@@ -1,15 +1,15 @@
-import 'package:azure_devops/src/services/azure_api_service.dart';
 import 'package:azure_devops/src/services/storage_service.dart';
 import 'package:collection/collection.dart';
 
-/// This class is responsible for persisting filters to local storage.
+/// This class is responsible for persisting filters to and retrieving them
+/// from local storage by using [storageService].
+/// 
+/// Filters can be different for each organization, that's why we need [organization].
 class FiltersService {
-  FiltersService({required this.storageService, required this.apiService});
+  FiltersService({required this.storageService, required this.organization});
 
   final StorageService storageService;
-  final AzureApiService apiService;
-
-  String get organization => apiService.organization;
+  final String organization;
 
   WorkItemsFilters getWorkItemsSavedFilters() {
     final workItemsFilters = _getAreaFilter(area: _FilterAreas.workItems);

--- a/lib/src/services/filters_service.dart
+++ b/lib/src/services/filters_service.dart
@@ -113,6 +113,43 @@ class FiltersService {
   void resetPipelinesFilters() {
     storageService.resetFilter(organization, _FilterAreas.pipelines);
   }
+
+  PullRequestsFilters getPullRequestsSavedFilters() {
+    final savedFilters = storageService.getFilters();
+
+    final pullRequestsFilters = savedFilters
+        .where(
+          (f) => f.organization == organization && f.area == _FilterAreas.pullRequests,
+        )
+        .toList();
+
+    return PullRequestsFilters(
+      projects: pullRequestsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
+      status: pullRequestsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.status)?.filters ?? {},
+      openedBy: pullRequestsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.openedBy)?.filters ?? {},
+      assignedTo: pullRequestsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.assignees)?.filters ?? {},
+    );
+  }
+
+  void savePullRequestsProjectsFilter(Set<String> projectNames) {
+    storageService.saveFilter(organization, _FilterAreas.pullRequests, _FilterKeys.projects, projectNames);
+  }
+
+  void savePullRequestsStatusFilter(String status) {
+    storageService.saveFilter(organization, _FilterAreas.pullRequests, _FilterKeys.status, {status});
+  }
+
+  void savePullRequestsOpenedByFilter(Set<String> userEmails) {
+    storageService.saveFilter(organization, _FilterAreas.pullRequests, _FilterKeys.openedBy, userEmails);
+  }
+
+  void savePullRequestsAssignedToFilter(Set<String> userEmails) {
+    storageService.saveFilter(organization, _FilterAreas.pullRequests, _FilterKeys.assignees, userEmails);
+  }
+
+  void resetPullRequestsFilters() {
+    storageService.resetFilter(organization, _FilterAreas.pullRequests);
+  }
 }
 
 class WorkItemsFilters {
@@ -153,12 +190,25 @@ class PipelinesFilters {
   final Set<String> status;
 }
 
+class PullRequestsFilters {
+  PullRequestsFilters({
+    required this.projects,
+    required this.status,
+    required this.openedBy,
+    required this.assignedTo,
+  });
+
+  final Set<String> projects;
+  final Set<String> status;
+  final Set<String> openedBy;
+  final Set<String> assignedTo;
+}
+
 class _FilterAreas {
   static const workItems = 'work-items';
   static const commits = 'commits';
   static const pipelines = 'pipelines';
-  // TODO
-  // static const pullRequests = 'pull-requests';
+  static const pullRequests = 'pull-requests';
 }
 
 // TODO move keys in each area class
@@ -171,4 +221,5 @@ class _FilterKeys {
   static const triggeredBy = 'triggeredBy';
   static const result = 'result';
   static const status = 'status';
+  static const openedBy = 'openedBy';
 }

--- a/lib/src/services/filters_service.dart
+++ b/lib/src/services/filters_service.dart
@@ -3,7 +3,7 @@ import 'package:collection/collection.dart';
 
 /// This class is responsible for persisting filters to and retrieving them
 /// from local storage by using [storageService].
-/// 
+///
 /// Filters can be different for each organization, that's why we need [organization].
 class FiltersService {
   FiltersService({required this.storageService, required this.organization});

--- a/lib/src/services/filters_service.dart
+++ b/lib/src/services/filters_service.dart
@@ -47,6 +47,33 @@ class FiltersService {
   void resetWorkItemsFilters() {
     storageService.resetFilter(organization, _FilterAreas.workItems);
   }
+
+  CommitsFilters getCommitsSavedFilters() {
+    final savedFilters = storageService.getFilters();
+
+    final savedCommitsFilters = savedFilters
+        .where(
+          (f) => f.organization == organization && f.area == _FilterAreas.commits,
+        )
+        .toList();
+
+    return CommitsFilters(
+      projects: savedCommitsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.projects)?.filters ?? {},
+      authors: savedCommitsFilters.firstWhereOrNull((f) => f.attribute == _FilterKeys.authors)?.filters ?? {},
+    );
+  }
+
+  void saveCommitsProjectsFilter(Set<String> projectNames) {
+    storageService.saveFilter(organization, _FilterAreas.commits, _FilterKeys.projects, projectNames);
+  }
+
+  void saveCommitsAuthorsFilter(Set<String> userEmails) {
+    storageService.saveFilter(organization, _FilterAreas.commits, _FilterKeys.authors, userEmails);
+  }
+
+  void resetCommitsFilters() {
+    storageService.resetFilter(organization, _FilterAreas.commits);
+  }
 }
 
 class WorkItemsFilters {
@@ -63,10 +90,20 @@ class WorkItemsFilters {
   final Set<String> assignees;
 }
 
+class CommitsFilters {
+  CommitsFilters({
+    required this.projects,
+    required this.authors,
+  });
+
+  final Set<String> projects;
+  final Set<String> authors;
+}
+
 class _FilterAreas {
   static const workItems = 'work-items';
+  static const commits = 'commits';
   // TODO
-  // static const commits = 'commits';
   // static const pipelines = 'pipelines';
   // static const pullRequests = 'pull-requests';
 }
@@ -76,4 +113,5 @@ class _FilterKeys {
   static const states = 'states';
   static const types = 'types';
   static const assignees = 'assignees';
+  static const authors = 'authors';
 }

--- a/lib/src/services/storage_service.dart
+++ b/lib/src/services/storage_service.dart
@@ -285,7 +285,7 @@ class StorageFilter {
     required this.attribute,
     required this.filters,
   });
-  
+
   factory StorageFilter.fromMap(Map<String, dynamic> map) {
     return StorageFilter(
       organization: map['organization'] as String,

--- a/test/api_service_mock.dart
+++ b/test/api_service_mock.dart
@@ -795,6 +795,17 @@ class StorageServiceMock implements StorageService {
 
   @override
   int get numberOfSessions => throw UnimplementedError();
+
+  @override
+  List<StorageFilter> getFilters() {
+    return [];
+  }
+
+  @override
+  void resetFilter(String organization, String area) {}
+
+  @override
+  void saveFilter(String organization, String area, String filterAttribute, Set<String> filters) {}
 }
 
 extension on WorkItem {


### PR DESCRIPTION
This PR adds support for filters that are persisted across app restarts by saving them to the device's local storage.
The filters of all app sections (commits, pipelines, work items and pull requests) are now persisted.

The `FiltersService` class is added to save and retrieve the filters to and from the storage, by using the `StorageService` class.

Close #11 